### PR TITLE
Use ghcr registry instead of dockerhub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,54 @@
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "^v?[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+env:
+  PLATFORMS: linux/amd64
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Determine tag or commit
+        uses: haya14busa/action-cond@v1
+        id: refortag
+        with:
+          cond: ${{ startsWith(github.ref, 'refs/tags/') }}
+          if_true: ${{ github.ref }}
+          if_false: latest
+      - name: Determine image tag
+        id: imagetag
+        run: echo "::set-output name=value::${TAG_OR_BRANCH##*/}"
+        env:
+          TAG_OR_BRANCH: ${{ steps.refortag.outputs.value }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: Build Apache Kafka
+        uses: docker/build-push-action@v2
+        with:
+          tags: ghcr.io/banzaicloud/kafka:${{ steps.imagetag.outputs.value }}
+          file: Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
This PR introduces a new GH action based flow to build docker images. It will store the image in ghcr.io instead of dockerhub