### PR TITLE
Migrate OpenJDK container images to Temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN cp NOTICE $kafka_release_dir
 RUN cp LICENSE $kafka_release_dir
 
 
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre
 
 ARG scala_version=2.13
 ARG kafka_version=2.7.1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Migrate OpenJDK container images to Temurin

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The AdoptOpenJDK has been rebranded and moved under the governance of Eclipse Foundation: https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/

The container images under the AdoptOpenJDK are not being updated anymore and new JDK versions are being released under the new name called Temurin.

We need to migrate our container images using JDK to Temurin to stay up to date and receive security patches.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
