### PR TITLE
Run Kafka on Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN tar -xzf $kafka_distro
 RUN rm -r kafka_$scala_version-$kafka_version/bin/windows
 
 
-FROM eclipse-temurin:11-jre-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 ARG scala_version=2.13
 ARG kafka_version=3.1.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Apache Kafka Docker Image
 
-Docker file for building docker image for [Apache Kafka](https://kafka.apache.org) from official [Apache Kafka Distros](https://www.apache.org/dyn/closer.cgi?path=/kafka/) running on Java 11.
+Docker file for building docker image for [Apache Kafka](https://kafka.apache.org) from official [Apache Kafka Distros](https://www.apache.org/dyn/closer.cgi?path=/kafka/) running on Java 17.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Run Apache Kafka 3.1.0 on Java 17

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Apache Kafka 3.1.0 supports now Java 17: https://downloads.apache.org/kafka/3.1.0/RELEASE_NOTES.html (https://issues.apache.org/jira/browse/KAFKA-13273)

