### PR TITLE
Bump JRE version to 17.0.3_7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN tar -xzf $kafka_distro
 RUN rm -r kafka_$scala_version-$kafka_version/bin/windows
 
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:17.0.3_7-jre
 
 ARG scala_version=2.13
 ARG kafka_version=3.1.0


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Bumped JRE version to 17.0.3_7

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
JRE version 17.0.3_7 includes fix for https://neilmadden.blog/2022/04/19/psychic-signatures-in-java/
