### PR TITLE
feature(main): support arm64 platform

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build Apache Kafka
         uses: docker/build-push-action@v4
         with:
-          tags: ghcr.io/banzaicloud/kafka:${{ steps.imagetag.outputs.value }}
+          tags: ghcr.io/${{ github.repository_owner }}/kafka:${{ steps.imagetag.outputs.value }}
           file: Dockerfile
           platforms: ${{ env.PLATFORMS }}
           push: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
       - "[0-9]+.[0-9]+-[0-9]+.[0-9]+.[0-9]+"
 #  pull_request:
 env:
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64
 jobs:
   docker:
     name: Docker
@@ -45,7 +45,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
       - name: Build Apache Kafka
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           tags: ghcr.io/banzaicloud/kafka:${{ steps.imagetag.outputs.value }}
           file: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,28 @@ ARG kafka_version=3.4.1
 ARG kafka_distro_base_url=https://dlcdn.apache.org/kafka
 
 ENV kafka_distro=kafka_$scala_version-$kafka_version.tgz
-ENV kafka_distro_asc=$kafka_distro.asc
-
-RUN apk add --no-cache gnupg
+ENV kafka_distro_sha512=$kafka_distro.sha512
 
 WORKDIR /var/tmp
-
+RUN apk add --no-cache coreutils
 RUN wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro
-RUN wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro_asc
-RUN wget -q $kafka_distro_base_url/KEYS
-
-RUN gpg --import KEYS
-RUN gpg --verify $kafka_distro_asc $kafka_distro
+RUN wget -q $kafka_distro_base_url/$kafka_version/$kafka_distro_sha512
+RUN set -e; \
+    # Calculate the SHA-512 checksum of the downloaded file
+    calculated_checksum=$(sha512sum $kafka_distro | awk '{print $1}'); \
+    \
+    # Extract and format the provided SHA-512 checksum from the file
+    provided_checksum=$(tr -d ' \n' < $kafka_distro_sha512 | cut -d':' -f2 | tr 'A-F' 'a-f'); \
+    \
+    echo "Calculated checksum: $calculated_checksum"; \
+    echo "Provided checksum:   $provided_checksum"; \
+    # Compare the two checksums and exit if they don't match
+    if [ "$calculated_checksum" != "$provided_checksum" ]; then \
+        echo "SHA-512 values do NOT match!"; \
+        exit 1; \
+    else \
+        echo "SHA-512 values match!"; \
+    fi
 
 RUN tar -xzf $kafka_distro
 RUN rm -r kafka_$scala_version-$kafka_version/bin/windows


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |  -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Support the docker image to arm64 platform.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The kafka-operator create kafkaCluster not support arm64 platform

Fixed: https://github.com/banzaicloud/koperator/issues/1067
### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

GitHub Action job: https://github.com/cuisongliu/koperator-docker-kafka/actions/runs/6518532772/job/17704050416

Image manifests : https://explore.ggcr.dev/?image=ghcr.io%2Fcuisongliu%2Fkafka%3A2.13-3.4.1-bzc7
### Checklist
- [x]  Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
~User guide and development docs updated (if needed)~
~Related Helm chart(s) updated (if needed)~